### PR TITLE
fixed rendering bug by direct referencing store object

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 FLASK_APP=app
 FLASK_ENV=development
-SECRET_KEY=lkasjdf09ajsdkfljalsiorj12n3490re9485309irefvn,u90818734902139489230
+SECRET_KEY=dfa21f5aw1ef6ad21fawef21as3df1a5w6ef1a21w6egstr1hd651jjdjrts5g1fd2
 DATABASE_URL=postgresql://starter_app_dev@localhost/starter_app

--- a/vue-app/src/components/User/User.vue
+++ b/vue-app/src/components/User/User.vue
@@ -1,6 +1,6 @@
 <script setup name='User'>
-import { ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
+import { onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import appStore from '../../stores/index'
 
@@ -9,39 +9,29 @@ const route = useRoute();
 const userId = route.params.userId;
 const userStore = appStore.useUserStore;
 const { userList } = storeToRefs(userStore);
-const user = ref(userStore.userList[userId]);
-console.log(userList.value)
 
-if (userList) {
-    console.log('inside userlist check')
-    console.log(user);
-    user.value = userList.value[userId];
-}
-
-console.log(user.value.email);
 if (!userId) {
     router.push('/');
 }
 
-watch(userList, (curr) => {
-    console.log('inside watch')
-    user.value = curr[userId]
-    console.log(user.value);
+onMounted(() => {
+    userStore.fetchUser(userId);
 })
+
 </script>
 
 
 <template>
     <ul>
-        <div v-if='user.id === userId'>
+        <div v-if='userList'>
             <li>
-                <strong>User Id</strong> {{user.id}}
+                <strong>User Id</strong> {{userList[userId].id}}
             </li>
             <li>
-                <strong>Username</strong> {{user.username}}
+                <strong>Username</strong> {{userList[userId].username}}
             </li>
             <li>
-                <strong>Email</strong> {{user.email}}
+                <strong>Email</strong> {{userList[userId].email}}
             </li>
         </div>
     </ul>

--- a/vue-app/src/stores/users.js
+++ b/vue-app/src/stores/users.js
@@ -23,8 +23,6 @@ const useUserStore = defineStore('UserStore', {
             if (response.ok) {
                 const loadedUser = await response.json();
                 this.userList[loadedUser.id] = loadedUser;
-                console.log('inside fetch');
-                console.log(loadedUser);
             }
         }
     }


### PR DESCRIPTION
Fixed a bug that was preventing the individual user page from rendering data. Remedied this by directly referencing the store object instead of creating a new ref. Also, when interacting with a storeToRef, you do not need to annotate with .value, a direct reference to the object is possible.